### PR TITLE
Add restart option for sync_directory.py

### DIFF
--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -239,7 +239,6 @@ def sync_directory(session, source, destination, logfile, verification_method="s
         if restartfile:
             print(f"Skipping files mentioned in restartfile {restartfile}")
             with open(restartfile, 'r') as data: 
-                print(data)
                 restart_info = json.load(data)
                 # Adding files that have to be skipped to our 'skipped' list for 
                 # this transfer.

--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -219,33 +219,33 @@ def sync_directory(session, source, destination, logfile, verification_method="s
 
     # adding try-finally so logfile is always written at the end,
     # even when serious errors occur or the user terminates the process.
-    try: 
+     
 
-        # For logging
-        skipped = []
-        succeeded = []
-        failed = []
-        cumulative_filesize_in_bytes = 0
+    # For logging
+    skipped = []
+    succeeded = []
+    failed = []
+    cumulative_filesize_in_bytes = 0
 
-        directories, files = list_directory_contents(source)
-        directories.append(source) # root not in list by default
-        # sort directories
-        directories.sort(key=lambda x: (x.count('/'), x))
+    directories, files = list_directory_contents(source)
+    directories.append(source) # root not in list by default
+    # sort directories
+    directories.sort(key=lambda x: (x.count('/'), x))
 
-        # If a restartfile is defined, 
-        # remove all files in the categories 'succeeded' and
-        # 'skipped' from the list 'files. These do not need to be checked/
-        # transferred again
-        if restartfile:
-            print(f"Skipping files mentioned in restartfile {restartfile}")
-            with open(restartfile, 'r') as data: 
-                restart_info = json.load(data)
-                # Adding files that have to be skipped to our 'skipped' list for 
-                # this transfer.
-                skipped.extend(restart_info['skipped'])
-                skipped.extend(restart_info ['succeeded'])
-                files = [ item for item in files if not (item in restart_info['skipped'] or item in restart_info ['succeeded']) ]
-
+    # If a restartfile is defined, 
+    # remove all files in the categories 'succeeded' and
+    # 'skipped' from the list 'files. These do not need to be checked/
+    # transferred again
+    if restartfile:
+        print(f"Skipping files mentioned in restartfile {restartfile}")
+        with open(restartfile, 'r') as data: 
+            restart_info = json.load(data)
+            # Adding files that have to be skipped to our 'skipped' list for 
+            # this transfer.
+            skipped.extend(restart_info['skipped'])
+            skipped.extend(restart_info ['succeeded'])
+            files = [ item for item in files if not (item in restart_info['skipped'] or item in restart_info ['succeeded']) ]
+    try:
         for directory in directories: 
             collection = directory.replace(str(Path(source).parent), destination)
             try:

--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -177,7 +177,7 @@ def list_directory_contents(path):
 
 
 
-def sync_directory(session, source, destination, verification_method="size", post_check=False, restartfile= None):
+def sync_directory(session, source, destination, logfile, verification_method="size", post_check=False, restartfile= None):
     """
     Synchronize a directory to iRODS
 
@@ -282,17 +282,21 @@ def sync_directory(session, source, destination, verification_method="size", pos
             "failed": failed,
             "cumulative_filesize_in_bytes": cumulative_filesize_in_bytes,
         }
-        write_results_to_log(results)
+        write_results_to_log(logfile, results)
 
         return results
 
-
-def write_results_to_log(results):
-    """Write results to a JSON file"""
+def generate_logfile_name():
+    """Generate a filename for a logfile"""
 
     date = datetime.datetime.now()
     formatted_date = date.strftime("%Y%m%d%H%M%S")
     filename = f"sync_log_{formatted_date}.json"
+
+    return filename
+
+def write_results_to_log(filename, results):
+    """Write results to a JSON file"""
 
     with open(filename, "w") as file:
         json.dump(results, file)
@@ -359,10 +363,13 @@ if __name__ == "__main__":
     ssl_settings = {"ssl_context": ssl_context}
 
     with iRODSSession(irods_env_file=env_file, **ssl_settings) as session:
+
+        # generate name for logfile
+        logfile = generate_logfile_name()
         # synchronize data to iRODS
         results = sync_directory(
-            session, args.source, args.destination, args.verification, args.post_check, args.restart_file
+            session, args.source, args.destination, logfile, args.verification, args.post_check, args.restart_file
         )
         #report in file and in standard output
-        write_results_to_log(results)
+        write_results_to_log(logfile, results)
         summarize(args.source, args.destination, results)

--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -279,6 +279,8 @@ def sync_directory(session, source, destination, logfile, verification_method="s
 
     finally:
         results = {
+            "source": source,
+            "destination": destination,
             "succeeded": succeeded,
             "skipped": skipped,
             "failed": failed,

--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -373,6 +373,5 @@ if __name__ == "__main__":
         results = sync_directory(
             session, args.source, args.destination, logfile, args.verification, args.post_check, args.restart_file
         )
-        #report in file and in standard output
-        write_results_to_log(logfile, results)
+        # report in standard output
         summarize(args.source, args.destination, results)

--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -241,9 +241,11 @@ def sync_directory(session, source, destination, logfile, verification_method="s
             with open(restartfile, 'r') as data: 
                 print(data)
                 restart_info = json.load(data)
-                restart_skipped = restart_info['skipped']
-                restart_succeeded = restart_info ['succeeded']
-                files = [ item for item in files if not (item in restart_skipped or item in restart_succeeded) ]
+                # Adding files that have to be skipped to our 'skipped' list for 
+                # this transfer.
+                skipped.extend(restart_info['skipped'])
+                skipped.extend(restart_info ['succeeded'])
+                files = [ item for item in files if not (item in restart_info['skipped'] or item in restart_info ['succeeded']) ]
 
         for directory in directories: 
             collection = directory.replace(str(Path(source).parent), destination)
@@ -312,7 +314,7 @@ def summarize(source, destination, results):
 
     print(f"{source} was synchronized to {destination}")
     print(
-        f"{number_skipped} files were skipped, because they were in a good state in iRODS."
+        f"{number_skipped} files were skipped."
     )
     print(f"{number_succeeded} files were uploaded successfully.")
     print(


### PR DESCRIPTION
I have implemented a restart option. The use case is: in case a large transfer fails halfway, you can now restart it where it left off. 
Files that were already transferred or skipped in the previous run, will not need to have their size checked or be checksummed.
This will make it faster to restart large transfers.

See also #4 

Now, if the transfer is cancelled mid-way (with e.g. ctrl+c), the 'finally' block will be executed and dump the logs in a log/restartfile.
This still needs to be made more robust: if the user would use ctrl+c multiple times, the finally-block will be broken off as well.
However, I wanted to share this first version already.

@w-lampaert, can you test this and let me know your comments?