### PR TITLE
fix: fix writing of failed filename to json results log file.

### DIFF
--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -223,7 +223,7 @@ def sync_directory(
                 size = session.data_objects.get(data_object).size
                 cumulative_filesize_in_bytes += size
             else:
-                failed.append(file)
+                failed.append(str(file))
         else:
             print(f"{data_object} was already uploaded with good status.")
             skipped.append(data_object)


### PR DESCRIPTION
Fix writing of failed filename to json results log file by converting Path object to str.

Before this patch, the follwoing exeception would be raised when failed files needed to be serialized to json:

    TypeError: Object of type PosixPath is not JSON serializable