### PR TITLE
Add last modify time to data object as metadata

### DIFF
--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -97,7 +97,7 @@ def create_modify_time_avu(path):
         # (since many Linux systems don't store more granularity)
         mtime_converted = (
             datetime.datetime.fromtimestamp(mtime)
-            .astimezone()
+            .astimezone(datetime.timezone.utc)
             .isoformat(timespec="seconds")
         )
     except:

--- a/irods/sync_directory.py
+++ b/irods/sync_directory.py
@@ -90,8 +90,15 @@ def create_modify_time_avu(path):
 
     try:
         mtime = os.path.getmtime(path)
-        mtime_converted = datetime.datetime.fromtimestamp(mtime).strftime(
-            "%Y%m%d:%H:%M:%S"
+        # The timestamp is converted from a string to a datetime object,
+        # so the timezone can be made explicit (offset to UTC),
+        # formatted following the ISO 8601 format,
+        # and has the granularity of seconds
+        # (since many Linux systems don't store more granularity)
+        mtime_converted = (
+            datetime.datetime.fromtimestamp(mtime)
+            .astimezone()
+            .isoformat(timespec="seconds")
         )
     except:
         mtime_converted = "unknown"


### PR DESCRIPTION
Adds the option to preserve last modified timestamps of files when uploading them in iRODS, by adding them as metadata.

I tried to separate the conversion of the timestamp from the function adding the metadata, so that other functions for extracting something as metadata can easily be added later. 

Exact format of the timestamp still may need to change (e.g. adding the milliseconds if needed).